### PR TITLE
📦 NEW: Bumping typer version to 0.3.0 from 0.2.1 for use with typer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.6"
 importlib_metadata = "^1.5"
-typer = "^0.2.1"
+typer = "^0.3.0"
 colorama = "^0.4.3"
 shellingham = "^1.3.2"
 


### PR DESCRIPTION
Bumping up typer version in pyproject.toml to 0.3.0 from 0.2.1 so typer-cli can be installed to run with typer 0.3.0 for auto-completion for non-packaged typer apps. 