### PR TITLE
Upgrade Typer version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "typer-cli"
-version = "0.0.10"
+version = "0.0.9"
 description = "Run Typer scripts with completion, without having to create a package, using Typer CLI."
 authors = ["Sebastián Ramírez <tiangolo@gmail.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "typer-cli"
-version = "0.0.9"
+version = "0.0.10"
 description = "Run Typer scripts with completion, without having to create a package, using Typer CLI."
 authors = ["Sebastián Ramírez <tiangolo@gmail.com>"]
 readme = "README.md"
@@ -36,7 +36,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.6"
 importlib_metadata = "^1.5"
-typer = "^0.2.1"
+typer = "^0.3.0"
 colorama = "^0.4.3"
 shellingham = "^1.3.2"
 

--- a/tests/assets/multiapp-docs.md
+++ b/tests/assets/multiapp-docs.md
@@ -64,7 +64,7 @@ $ multiapp sub hello [OPTIONS]
 
 **Options**:
 
-* `--name TEXT`
+* `--name TEXT`: [default: World]
 * `--help`: Show this message and exit.
 
 ## `multiapp top`


### PR DESCRIPTION
⬆️ Upgrade Typer version to 0.3.0
- Added default string to multiapp-docs.md to match Typer 0.3.0 capabilities and fix tests