### PR TITLE
🐛 Fix GitHub action latest changes header to use the current one

### DIFF
--- a/.github/workflows/latest-changes.yml
+++ b/.github/workflows/latest-changes.yml
@@ -15,3 +15,4 @@ jobs:
       - uses: docker://tiangolo/latest-changes:0.0.1
         with:
           latest_changes_file: release-notes.md
+          latest_changes_header: '## Latest Changes\n\n'


### PR DESCRIPTION
🐛 Fix GitHub action latest changes header to use the current one