### PR TITLE
Add title option for auto-generated docs

### DIFF
--- a/typer_cli/main.py
+++ b/typer_cli/main.py
@@ -274,7 +274,8 @@ def docs(
     title: str = typer.Option(
         "",
         help="The title for the documentation page. If not provided, the name of "
-             "the program is used."),
+        "the program is used.",
+    ),
 ) -> None:
     """
     Generate Markdown docs for a Typer app.

--- a/typer_cli/main.py
+++ b/typer_cli/main.py
@@ -188,12 +188,14 @@ def get_docs_for_click(
     indent: int = 0,
     name: str = "",
     call_prefix: str = "",
+    title: str = "",
 ) -> str:
     docs = "#" * (1 + indent)
     command_name = name or obj.name
     if call_prefix:
         command_name = f"{call_prefix} {command_name}"
-    title = f"`{command_name}`" if command_name else "CLI"
+    if not title:
+        title = f"`{command_name}`" if command_name else "CLI"
     docs += f" {title}\n\n"
     if obj.help:
         docs += f"{obj.help}\n\n"
@@ -269,6 +271,10 @@ def docs(
         file_okay=True,
         dir_okay=False,
     ),
+    title: str = typer.Option(
+        "",
+        help="The title for the documentation page. If not provided, the name of "
+             "the program is used."),
 ) -> None:
     """
     Generate Markdown docs for a Typer app.
@@ -278,7 +284,7 @@ def docs(
         typer.echo(f"No Typer app found", err=True)
         raise typer.Abort()
     click_obj = typer.main.get_command(typer_obj)
-    docs = get_docs_for_click(obj=click_obj, ctx=ctx, name=name)
+    docs = get_docs_for_click(obj=click_obj, ctx=ctx, name=name, title=title)
     clean_docs = f"{docs.strip()}\n"
     if output:
         output.write_text(clean_docs)


### PR DESCRIPTION
This small change allows the user to change the documentation page title. This makes it possible to have documentation with a nicer title like "Foo Command Line Interface" rather than something like "`python -m Foo`"