### PR TITLE
Relax version constraints for typer dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 
 dynamic = ["version"]
 dependencies = [
-"typer >=0.4.0,<=0.7.0",
+"typer >=0.4.0,<=0.9.0",
 "colorama >=0.4.3,<=0.5.0",
 "shellingham >=1.3.2,<=1.4.0",
 ]


### PR DESCRIPTION
`typer-cli` provides a nice way to automatically generate the documentation for Typer apps, but you can't currently use it with the latest version of `typer`. It appears we just need to relax the dependency requirements, as all of the existing test cases pass when bumping the version.

Fixes #118 