### PR TITLE
Change the version constrains of typer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 
 dynamic = ["version"]
 dependencies = [
-"typer >=0.4.0,<=0.7.0",
+"typer >=0.4.0,<1.0.0",
 "colorama >=0.4.3,<=0.5.0",
 "shellingham >=1.3.2,<=1.4.0",
 ]


### PR DESCRIPTION
## Motivation
We would like to the awesome typer-cli with typer. Although the latest version of typer is 0.9.0, it would be good to follow the future release by the upper bound with `<1.0.0`.